### PR TITLE
Handle situations where the given step was not met

### DIFF
--- a/audit/probes.go
+++ b/audit/probes.go
@@ -12,6 +12,7 @@ type Probe struct {
 	ScenariosAttempted int
 	ScenariosSucceeded int
 	ScenariosFailed    int
+	GivenNotMet        int
 	Result             string
 	Scenarios          map[int]*Scenario
 }
@@ -22,6 +23,7 @@ type limitedProbe struct {
 	ScenariosAttempted int                    `json:"ScenariosAttempted"`
 	ScenariosSucceeded int                    `json:"ScenariosSucceeded"`
 	ScenariosFailed    int                    `json:"ScenariosFailed"`
+	GivenNotMet        int                    `json:"GivenNotMet"`
 	Result             string                 `json:"Result"`
 }
 
@@ -33,6 +35,8 @@ func (e *Probe) countResults() {
 			e.ScenariosFailed = e.ScenariosFailed + 1
 		} else if v.Result == "Passed" {
 			e.ScenariosSucceeded = e.ScenariosSucceeded + 1
+		} else if v.Result == "Given Not Met" {
+			e.GivenNotMet = e.GivenNotMet + 1
 		}
 	}
 }

--- a/audit/summary.go
+++ b/audit/summary.go
@@ -128,9 +128,12 @@ func (s *SummaryState) completeProbe(e *Probe) {
 		e.Result = "No Scenarios Executed"
 		e.Meta["audit_path"] = ""
 		s.ProbesSkipped = s.ProbesSkipped + 1
-	} else if e.ScenariosFailed < 1 {
+	} else if e.ScenariosAttempted == e.ScenariosSucceeded {
 		e.Result = "Success"
 		s.ProbesPassed = s.ProbesPassed + 1
+	} else if e.ScenariosAttempted == e.GivenNotMet {
+		e.Result = "Given was Not Met"
+		s.ProbesSkipped = s.ProbesSkipped + 1
 	} else {
 		e.Result = "Failed"
 		s.ProbesFailed = s.ProbesFailed + 1

--- a/probeengine/feature_probe_handler.go
+++ b/probeengine/feature_probe_handler.go
@@ -22,13 +22,13 @@ func toFileGodogProbeHandler(gd *GodogProbe) (int, *bytes.Buffer, error) {
 		return -1, nil, err
 	}
 
-	status, err := runTestSuite(o, gd)
+	status := runTestSuite(o, gd)
 
-	//FUDGE! If the tests are skipped due to tags, then an empty file may
-	//be left lingering.  This will have a non-zero size as we've actually
-	//had to create the file prior to the test run (see line 31).  If it's
-	//less than 4 bytes, it's fairly certain that this will indeed be empty
-	//and can be removed.
+	// If the tests are skipped due to tags, then an empty file may
+	// be left lingering.  This will have a non-zero size as we've actually
+	// had to create the file prior to the test run (see line 31).  If it's
+	// less than 4 bytes, it's fairly certain that this will indeed be empty
+	// and can be removed.
 	i, err := o.Stat()
 	s := i.Size()
 	o.Close()
@@ -50,7 +50,7 @@ func toFileGodogProbeHandler(gd *GodogProbe) (int, *bytes.Buffer, error) {
 // 	return status, o, err
 // }
 
-func runTestSuite(o io.Writer, gd *GodogProbe) (int, error) {
+func runTestSuite(o io.Writer, gd *GodogProbe) int {
 	opts := godog.Options{
 		Format: config.GlobalConfig.GodogResultsFormat,
 		Output: colors.Colored(o),
@@ -65,5 +65,5 @@ func runTestSuite(o io.Writer, gd *GodogProbe) (int, error) {
 		Options:              &opts,
 	}.Run()
 
-	return status, nil
+	return status
 }


### PR DESCRIPTION
1) corrected handling when a scenario's given step is not met
2) corrected the old "FUDGE" comment & a bad return value that I stumbled across

**Output:**
![image](https://user-images.githubusercontent.com/21176439/118641864-aaa10480-b7a8-11eb-8340-c0343f50cefe.png)

_NOTE: I need to follow up with another PR that addresses the fact that we aren't really identifying the given properly... we're just assuming the first step is always a given_