### PR TITLE
Added common kubernetes config options to provider

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -3,12 +3,14 @@ package config
 import (
 	"time"
 
-	azureconfig "github.com/probr/probr-sdk/providers/azure/config"
+	ac "github.com/probr/probr-sdk/providers/azure/config"
+	kc "github.com/probr/probr-sdk/providers/kubernetes/config"
 )
 
 // CloudProviders config options
 type CloudProviders struct {
-	Azure azureconfig.Azure `yaml:"Azure"`
+	Azure      ac.Azure      `yaml:"Azure"`
+	Kubernetes kc.Kubernetes `yaml:"Kubernetes"`
 }
 
 // GlobalOpts provides configurable options that will be used throughout the SDK

--- a/providers/kubernetes/config/type.go
+++ b/providers/kubernetes/config/type.go
@@ -1,0 +1,34 @@
+package kubernetesconfig
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/probr/probr-sdk/config/setter"
+)
+
+type Kubernetes struct {
+	KeepPods                 string `yaml:"KeepPods"` // TODO: Change type to bool, this would allow us to remove logic from kubernetes.GetKeepPodsFromConfig()
+	KubeConfigPath           string `yaml:"KubeConfig"`
+	KubeContext              string `yaml:"KubeContext"`
+	AuthorisedContainerImage string `yaml:"AuthorisedContainerImage"`
+	ProbeNamespace           string `yaml:"ProbeNamespace"`
+}
+
+// setEnvOrDefaults will set value from os.Getenv and default to the specified value
+func (ctx *Kubernetes) SetEnvAndDefaults() {
+	// Notes on SetVar's values:
+	// 1. Pointer to local object; will be overwritten by env or default if empty
+	// 2. Name of env var to check
+	// 3. Default value to set if flags, vars file, and env have not provided a value
+
+	setter.SetVar(&ctx.KeepPods, "PROBR_KEEP_PODS", "false")
+	setter.SetVar(&ctx.KubeConfigPath, "KUBE_CONFIG", getDefaultKubeConfigPath())
+	setter.SetVar(&ctx.KubeContext, "KUBE_CONTEXT", "")
+	setter.SetVar(&ctx.AuthorisedContainerImage, "PROBR_AUTHORISED_IMAGE", "")
+}
+
+func getDefaultKubeConfigPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".kube", "config")
+}

--- a/providers/kubernetes/config/type.go
+++ b/providers/kubernetes/config/type.go
@@ -9,7 +9,7 @@ import (
 
 // Kubernetes contains common variables needed when using the Kubernetes provider
 type Kubernetes struct {
-	KeepPods                 string `yaml:"KeepPods"` // TODO: Change type to bool, this would allow us to remove logic from kubernetes.GetKeepPodsFromConfig()
+	KeepPods                 string `yaml:"KeepPods"`
 	KubeConfigPath           string `yaml:"KubeConfig"`
 	KubeContext              string `yaml:"KubeContext"`
 	AuthorisedContainerImage string `yaml:"AuthorisedContainerImage"`

--- a/providers/kubernetes/config/type.go
+++ b/providers/kubernetes/config/type.go
@@ -15,7 +15,7 @@ type Kubernetes struct {
 	ProbeNamespace           string `yaml:"ProbeNamespace"`
 }
 
-// setEnvOrDefaults will set value from os.Getenv and default to the specified value
+// SetEnvOrDefaults will set value from os.Getenv and default to the specified value
 func (ctx *Kubernetes) SetEnvAndDefaults() {
 	// Notes on SetVar's values:
 	// 1. Pointer to local object; will be overwritten by env or default if empty

--- a/providers/kubernetes/config/type.go
+++ b/providers/kubernetes/config/type.go
@@ -7,6 +7,7 @@ import (
 	"github.com/probr/probr-sdk/config/setter"
 )
 
+// Kubernetes contains common variables needed when using the Kubernetes provider
 type Kubernetes struct {
 	KeepPods                 string `yaml:"KeepPods"` // TODO: Change type to bool, this would allow us to remove logic from kubernetes.GetKeepPodsFromConfig()
 	KubeConfigPath           string `yaml:"KubeConfig"`
@@ -15,7 +16,7 @@ type Kubernetes struct {
 	ProbeNamespace           string `yaml:"ProbeNamespace"`
 }
 
-// SetEnvOrDefaults will set value from os.Getenv and default to the specified value
+// SetEnvAndDefaults will set value from os.Getenv and default to the specified value
 func (ctx *Kubernetes) SetEnvAndDefaults() {
 	// Notes on SetVar's values:
 	// 1. Pointer to local object; will be overwritten by env or default if empty

--- a/providers/kubernetes/config/type.go
+++ b/providers/kubernetes/config/type.go
@@ -18,11 +18,6 @@ type Kubernetes struct {
 
 // SetEnvAndDefaults will set value from os.Getenv and default to the specified value
 func (ctx *Kubernetes) SetEnvAndDefaults() {
-	// Notes on SetVar's values:
-	// 1. Pointer to local object; will be overwritten by env or default if empty
-	// 2. Name of env var to check
-	// 3. Default value to set if flags, vars file, and env have not provided a value
-
 	setter.SetVar(&ctx.KeepPods, "PROBR_KEEP_PODS", "false")
 	setter.SetVar(&ctx.KubeConfigPath, "KUBE_CONFIG", getDefaultKubeConfigPath())
 	setter.SetVar(&ctx.KubeContext, "KUBE_CONTEXT", "")

--- a/providers/kubernetes/config/type.go
+++ b/providers/kubernetes/config/type.go
@@ -22,6 +22,7 @@ func (ctx *Kubernetes) SetEnvAndDefaults() {
 	setter.SetVar(&ctx.KubeConfigPath, "KUBE_CONFIG", getDefaultKubeConfigPath())
 	setter.SetVar(&ctx.KubeContext, "KUBE_CONTEXT", "")
 	setter.SetVar(&ctx.AuthorisedContainerImage, "PROBR_AUTHORISED_IMAGE", "")
+	setter.SetVar(&ctx.ProbeNamespace, "PROBR_K8S_PROBE_NAMESPACE", "probr-general-test-ns")
 }
 
 func getDefaultKubeConfigPath() string {


### PR DESCRIPTION
Gives the ability for AKS and Kubernetes service pack to share this config object.

Is not a breaking change, as it's optional to use. Is not technically a new (minor semver) feature, because it does not modify functionality even when used.