### PR TITLE
Correcting non-verbose errors for bad config in Azure client

### DIFF
--- a/providers/azure/azurebase.go
+++ b/providers/azure/azurebase.go
@@ -1,80 +1,59 @@
 package azure
 
 import (
-	"log"
-	"os"
-
 	"github.com/probr/probr-sdk/config"
 	"github.com/probr/probr-sdk/utils"
 )
 
-var prefix string
-var rgName string
-
-//TenantID returns the azure Tenant in which the tests should be executed, configured by the user and may be set by the environment variable AZURE_TENANT_ID.
-func TenantID() string {
+// TenantID returns the azure Tenant in which the tests should be executed, configured by the user and may be set by the environment variable AZURE_TENANT_ID.
+func TenantID() (string, error) {
 	if config.GlobalConfig.CloudProviders.Azure.TenantID == "" {
-		log.Printf("[ERROR] Azure connection config var not set: config.GlobalConfig.CloudProviders.Azure.TenantID")
+		return "", utils.ReformatError("Required config var not set: CloudProviders.Azure.TenantID")
 	}
-	return config.GlobalConfig.CloudProviders.Azure.TenantID
+	return config.GlobalConfig.CloudProviders.Azure.TenantID, nil
 }
 
-//ClientID returns the client (typically a service principal) that must be authorized for performing operations within the azure tenant, configured by the user and may be set by the environment variable AZURE_CLIENT_ID.
-func ClientID() string {
+// ClientID returns the client (typically a service principal) that must be authorized for performing operations within the azure tenant, configured by the user and may be set by the environment variable AZURE_CLIENT_ID.
+func ClientID() (string, error) {
 	if config.GlobalConfig.CloudProviders.Azure.ClientID == "" {
-		log.Printf("[ERROR] Azure connection config var not set: config.GlobalConfig.CloudProviders.Azure.ClientID")
+		return "", utils.ReformatError("Required config var not set: CloudProviders.Azure.ClientID")
 	}
-	return config.GlobalConfig.CloudProviders.Azure.ClientID
+	return config.GlobalConfig.CloudProviders.Azure.ClientID, nil
 }
 
-//ClientSecret returns the client secret to allow client authetication and authorization, configured by the user and may be set by the environment variable AZURE_CLIENT_SECRET.
-func ClientSecret() string {
+// ClientSecret returns the client secret to allow client authetication and authorization, configured by the user and may be set by the environment variable AZURE_CLIENT_SECRET.
+func ClientSecret() (string, error) {
 	if config.GlobalConfig.CloudProviders.Azure.ClientSecret == "" {
-		log.Printf("[ERROR] Azure connection config var not set: config.GlobalConfig.CloudProviders.Azure.ClientSecret")
+		return "", utils.ReformatError("Required config var not set: CloudProviders.Azure.ClientSecret")
 	}
-	return config.GlobalConfig.CloudProviders.Azure.ClientSecret
+	return config.GlobalConfig.CloudProviders.Azure.ClientSecret, nil
 }
 
-//SubscriptionID returns the azure Subscription in which the tests should be executed, configured by the user and may be set by the environment variable AZURE_SUBSCRIPTION_ID.
-func SubscriptionID() string {
+// SubscriptionID returns the azure Subscription in which the tests should be executed, configured by the user and may be set by the environment variable AZURE_SUBSCRIPTION_ID.
+func SubscriptionID() (string, error) {
 	if config.GlobalConfig.CloudProviders.Azure.SubscriptionID == "" {
-		log.Printf("[ERROR] Azure connection config var not set: config.GlobalConfig.CloudProviders.Azure.SubscriptionID")
+		return "", utils.ReformatError("Required config var not set: CloudProviders.Azure.SubscriptionID")
 	}
-	return config.GlobalConfig.CloudProviders.Azure.SubscriptionID
+	return config.GlobalConfig.CloudProviders.Azure.SubscriptionID, nil
 }
 
-//ResourceGroup returns the Probr user's azure resource group in which resurces should be created fpr testing, configured by the user and may be set by the environment variable AZURE_RESOURCE_GROUP.
-func ResourceGroup() string {
+// ResourceGroup returns the Probr user's azure resource group in which resurces should be created fpr testing, configured by the user and may be set by the environment variable AZURE_RESOURCE_GROUP.
+func ResourceGroup() (string, error) {
 	if config.GlobalConfig.CloudProviders.Azure.ResourceGroup == "" {
-		log.Printf("[ERROR] Azure connection config var not set: config.GlobalConfig.CloudProviders.Azure.ResourceGroup")
+		return "", utils.ReformatError("Required config var not set: CloudProviders.Azure.ResourceGroup")
 	}
-	return config.GlobalConfig.CloudProviders.Azure.ResourceGroup
+	return config.GlobalConfig.CloudProviders.Azure.ResourceGroup, nil
 }
 
-//ResourceLocation returns the default location in which azure resources should be created, configured by the user and may be set by the environment variable AZURE_LOCATION.
-func ResourceLocation() string {
+// ResourceLocation returns the default location in which azure resources should be created, configured by the user and may be set by the environment variable AZURE_LOCATION.
+func ResourceLocation() (string, error) {
 	if config.GlobalConfig.CloudProviders.Azure.ResourceLocation == "" {
-		log.Printf("[ERROR] Azure connection config var not set: config.GlobalConfig.CloudProviders.Azure.ResourceLocation")
+		return "", utils.ReformatError("Required config var not set: CloudProviders.Azure.ResourceLocation")
 	}
-	return config.GlobalConfig.CloudProviders.Azure.ResourceLocation
+	return config.GlobalConfig.CloudProviders.Azure.ResourceLocation, nil
 }
 
-//ManagementGroup returns an Azure Management Group which may be used for policy assignment, configured by the user and may be set by the environment variable AZURE_MANAGEMENT_GROUP.
+// ManagementGroup returns an Azure Management Group which may be used for policy assignment, configured by the user and may be set by the environment variable AZURE_MANAGEMENT_GROUP.
 func ManagementGroup() string {
 	return config.GlobalConfig.CloudProviders.Azure.ManagementGroup
-}
-
-func randomPrefix() string {
-	if prefix == "" {
-		prefix = "test" + utils.RandomString(6) + ""
-	}
-	return "test" + utils.RandomString(6) + ""
-}
-
-func getFromEnvVar(varName string) string {
-	v, b := os.LookupEnv(varName)
-	if !b {
-		log.Printf("[ERROR] Environment variable \"%v\" is not defined", varName)
-	}
-	return v
 }

--- a/providers/azure/connection/aks.go
+++ b/providers/azure/connection/aks.go
@@ -56,7 +56,7 @@ func (amc *AzureManagedCluster) GetJSONRepresentation(resourceGroupName string, 
 	var cs containerservice.ManagedCluster
 	cs, err = amc.azManagedClustersClient.Get(amc.ctx, resourceGroupName, clusterName)
 	if err != nil {
-		log.Printf("Error getting ContainerServiceClient: %v", err)
+		log.Printf("[ERROR] Failed to retrieve ContainerServiceClient: %v", err)
 		return
 	}
 	aksJSON, err = cs.MarshalJSON()

--- a/providers/azure/connection/azure.go
+++ b/providers/azure/connection/azure.go
@@ -136,7 +136,6 @@ func (az *AzureConnection) DeleteStorageAccount(resourceGroupName, accountName s
 
 // GetManagedClusterJSON returns the JSON representation of an AKS cluster, similar to az aks show. NOTE that the output from this function has differences to the az cli that needs to be accomodated if you are using the JSON created by this function.
 func (az *AzureConnection) GetManagedClusterJSON(resourceGroupName, clusterName string) ([]byte, error) {
-	// Currently experiencing a nil pointer dereference panic
 	log.Printf("[DEBUG] getting JSON for AKS Cluster '%s'", clusterName)
 	return az.ManagedCluster.GetJSONRepresentation(resourceGroupName, clusterName)
 }

--- a/providers/azure/connection/azure.go
+++ b/providers/azure/connection/azure.go
@@ -52,7 +52,7 @@ var instance *AzureConnection
 var once sync.Once
 
 // NewAzureConnection provides a singleton instance of AzureConnection. Initializes all internal clients to interact with Azure.
-func NewAzureConnection(c context.Context, subscriptionID, tenantID, clientID, clientSecret string) (azConn *AzureConnection) {
+func NewAzureConnection(c context.Context, subscriptionID, tenantID, clientID, clientSecret string) *AzureConnection {
 	once.Do(func() {
 		// Guard clause
 		if c == nil {
@@ -136,6 +136,7 @@ func (az *AzureConnection) DeleteStorageAccount(resourceGroupName, accountName s
 
 // GetManagedClusterJSON returns the JSON representation of an AKS cluster, similar to az aks show. NOTE that the output from this function has differences to the az cli that needs to be accomodated if you are using the JSON created by this function.
 func (az *AzureConnection) GetManagedClusterJSON(resourceGroupName, clusterName string) ([]byte, error) {
+	// Currently experiencing a nil pointer dereference panic
 	log.Printf("[DEBUG] getting JSON for AKS Cluster '%s'", clusterName)
 	return az.ManagedCluster.GetJSONRepresentation(resourceGroupName, clusterName)
 }

--- a/providers/azure/connection/storage.go
+++ b/providers/azure/connection/storage.go
@@ -60,7 +60,10 @@ func (sa *AzureStorageAccount) getStorageAccountClient(creds AzureCredentials) (
 
 // Create starts creation of a new Storage Account and waits for the account to be created.
 func (sa *AzureStorageAccount) Create(accountName, accountGroupName string, tags map[string]*string, httpsOnly bool, networkRuleSet *storage.NetworkRuleSet) (storage.Account, error) {
-
+	resourceLocation, err := azure.ResourceLocation()
+	if err != nil {
+		return storage.Account{}, err
+	}
 	log.Printf("[DEBUG] creating Storage Account '%s'", accountName)
 
 	var storageAccount storage.Account
@@ -93,7 +96,7 @@ func (sa *AzureStorageAccount) Create(accountName, accountGroupName string, tags
 			Sku: &storage.Sku{
 				Name: storage.StandardLRS},
 			Kind:                              storage.Storage,
-			Location:                          to.StringPtr(azure.ResourceLocation()),
+			Location:                          &resourceLocation,
 			AccountPropertiesCreateParameters: networkRuleSetParam,
 			Tags:                              tags,
 		})


### PR DESCRIPTION
Added handling to enable checks on required variables, so we don't continue to experience silent failures when bad config is supplied by the user